### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
@@ -91,7 +91,7 @@ jobs:
         if: ${{ matrix.configuration == 'Release' }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.3.6
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: TekuSP-Drivers


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.6](https://github.com/actions/upload-artifact/releases/tag/v4.3.6)** on 2024-08-06T14:41:41Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.2](https://github.com/actions/setup-java/releases/tag/v4.2.2)** on 2024-08-05T14:04:36Z
