### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/Drivers/IT8951/IT8951.nfproj
+++ b/Drivers/IT8951/IT8951.nfproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -31,25 +31,17 @@
     <ProjectReference Include="..\DriverBase\DriverBase.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.12.0.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.12.0\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.10.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.10.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Gpio, Version=1.0.4.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.0.4\lib\System.Device.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio, Version=1.1.57.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Gpio.1.1.57\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Spi, Version=1.2.1.12878, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Spi.1.2.1\lib\System.Device.Spi.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Spi, Version=1.3.82.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Spi.1.3.82\lib\System.Device.Spi.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Drivers/IT8951/IT8951.nuspec
+++ b/Drivers/IT8951/IT8951.nuspec
@@ -22,10 +22,10 @@
     <dependencies>
       <dependency id="TekuSP.Drivers.DriverBase" version="$version$" />
       <dependency id="TekuSP.Drivers.DriverBaseSPI" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.12.0" />
-	  <dependency id="nanoFramework.Runtime.Events" version="1.10.0" />
-      <dependency id="nanoFramework.System.Device.Gpio" version="1.0.4" />
-      <dependency id="nanoFramework.System.Device.Spi" version="1.2.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+      <dependency id="nanoFramework.System.Device.Gpio" version="1.1.57" />
+      <dependency id="nanoFramework.System.Device.Spi" version="1.3.82" />
     </dependencies>
   </metadata>
   <files>

--- a/Drivers/IT8951/packages.config
+++ b/Drivers/IT8951/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.12.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.10.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Spi" version="1.2.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Spi" version="1.3.82" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.12.0 to 1.17.11</br>Bumps nanoFramework.Runtime.Events from 1.10.0 to 1.11.32</br>Bumps nanoFramework.System.Device.Gpio from 1.0.4 to 1.1.57</br>Bumps nanoFramework.System.Device.Spi from 1.2.1 to 1.3.82</br>
[version update]

### :warning: This is an automated update. :warning:
